### PR TITLE
added toolchains 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,7 +79,7 @@ pipeline {
                         }
                     }
                 }
-
+/*
                 stage('Windows Java 9') {
                     agent {
                         node {
@@ -138,7 +138,7 @@ pipeline {
                             cleanWs()
                         }
                     }
-                }
+                }*/
 
             }
         }

--- a/mat-file-io/pom.xml
+++ b/mat-file-io/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>us.hebi.matlab</groupId>
@@ -74,7 +75,7 @@
 
         <!-- Other Settings -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <gpg.keyname /> <!-- set via settings.xml to sign release artifacts-->
+        <gpg.keyname/> <!-- set via settings.xml to sign release artifacts-->
 
         <!-- License Headers (http://www.mojohaus.org/license-maven-plugin/update-file-header-mojo.html) -->
         <license.licenseName>apache_v2</license.licenseName>
@@ -155,9 +156,17 @@
                             <excludes>
                                 <exclude>module-info.java</exclude>
                             </excludes>
+                            <jdkToolchain>
+                                <version>[1.6,9)</version>
+                            </jdkToolchain>
                         </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <jdkToolchain>
+                        <version>[9,)</version>
+                    </jdkToolchain>
+                </configuration>
             </plugin>
 
             <!-- Add licenses to files -->

--- a/mat-file-io/src/main/java/us/hebi/matlab/common/memory/NativeMemory.java
+++ b/mat-file-io/src/main/java/us/hebi/matlab/common/memory/NativeMemory.java
@@ -96,7 +96,7 @@ public class NativeMemory {
             try {
                 cleanMethod.invoke(getCleanerMethod.invoke(buffer));
             } catch (Exception e) {
-                throw new AssertionError("Java 6 Cleaner failed to free DirectBuffer", e);
+                throw new AssertionError("Java 6 Cleaner failed to free DirectBuffer");
             }
         }
 
@@ -105,7 +105,7 @@ public class NativeMemory {
                 getCleanerMethod = Class.forName("sun.nio.ch.DirectBuffer").getMethod("cleaner");
                 cleanMethod = Class.forName("sun.misc.Cleaner").getMethod("clean");
             } catch (Exception e) {
-                throw new AssertionError("Java 6 Cleaner not available", e);
+                throw new AssertionError("Java 6 Cleaner not available");
             }
         }
 
@@ -123,7 +123,7 @@ public class NativeMemory {
             try {
                 INVOKE_CLEANER.invoke(UnsafeAccess.UNSAFE, buffer);
             } catch (Exception e) {
-                throw new AssertionError("Java 9 Cleaner failed to free DirectBuffer", e);
+                throw new AssertionError("Java 9 Cleaner failed to free DirectBuffer");
             }
         }
 
@@ -131,7 +131,7 @@ public class NativeMemory {
             try {
                 INVOKE_CLEANER = UnsafeAccess.UNSAFE.getClass().getMethod("invokeCleaner", ByteBuffer.class);
             } catch (Exception e) {
-                throw new AssertionError("Java 9 Cleaner not available", e);
+                throw new AssertionError("Java 9 Cleaner not available");
             }
         }
 


### PR DESCRIPTION
* Changed to using `toolchains.xml` to generate java 6 sources with jdk6

This is needed because JDK 9 with Java 6 target/source does not guarantee binary compatibility. This fixes #15 

* This needs to be setup on CI as well, so Java 9 builds are disabled for now